### PR TITLE
bob-builder downgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-bob-builder>=0.0.15
+bob-builder>=0.0.15,<0.0.19
 s3cmd>=1.6.0


### PR DESCRIPTION
The latest version of bob-builder doesn't set the S3 ACL after uploading artifacts, this change will ensure we don't use this version.